### PR TITLE
Add version to health endpoint

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -2,12 +2,17 @@ FROM julia:1.9
 WORKDIR /sciml-service
 
 # Install SimulationService.jl
+ENV JULIA_PROJECT=.
 COPY Project.toml /sciml-service/
 COPY Manifest.toml /sciml-service/
+RUN julia -e 'using Pkg; Pkg.instantiate();'
 COPY src/ /sciml-service/src/
 COPY examples/ /sciml-service/examples/
-ENV JULIA_PROJECT=.
-RUN julia -e 'using Pkg; Pkg.instantiate();'
+
+COPY .git/HEAD .git/HEAD
+COPY .git/refs .git/refs
+RUN grep '^ref:' .git/HEAD && cp .git/`cat .git/HEAD | awk '/^ref: / {print $2}'` .version || cp .git/HEAD /sciml-service/.version
+RUN rm -fr .git
 
 # Launch sciml-service
 EXPOSE 8080


### PR DESCRIPTION
The healthcheck has been moved from '/' to '/health' and now includes the Git SHA. Also, the Dockerfile has been refactored to not build dependencies when there's only a change in source. The context for this change can be found [here](https://github.com/DARPA-ASKEM/simulation-integration/issues/13#issuecomment-1755483569).

@mwdchang FYI this will probably need a change on the Terarium side since it's checking using `/`.