### PR TITLE
Fixed optimization callback to return false, added opt counter

### DIFF
--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -58,6 +58,9 @@ const RABBITMQ_ROUTE = Ref{String}()
 const RABBITMQ_HOST = Ref{String}()
 const RABBITMQ_PORT = Ref{Int}()
 
+# I don't like this, but needed for now to count optimization iterations 
+opt_callback_counter = Ref{Int}()
+
 function __init__()
     if Threads.nthreads() == 1
         @warn "SimulationService.jl expects `Threads.nthreads() > 1`.  Use e.g. `julia --threads=auto`."

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -216,7 +216,7 @@ function solve(o::Calibrate; callback)
     prob = ODEProblem(o.sys, [], o.timespan)
     statenames = [states(o.sys);getproperty.(observed(o.sys), :lhs)]
 
-    opt_iter_counter[] = 0
+    opt_callback_counter[] = 0
     # bayesian datafit 
     if o.calibrate_method == "bayesian"
         p_posterior = EasyModelAnalysis.bayesian_datafit(prob, o.priors, o.data;


### PR DESCRIPTION
I don't like using a reference to count the iterations, but it should only be temporary. Soon I should be able to get it directly from the solution stats in the callback. Depending on changes in Optimization.jl.