### PR TITLE
use the mappings tstep as timestamp

### DIFF
--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -419,7 +419,7 @@ function get_dataset(obj::JSON3.Object)
         @info "`get_dataset` (dataset id=$(repr(obj.id))) rename! $k => $v"
         rename!(df, k => v)
     end
-    "timestep" in names(df) && rename!(df, "timestep" => "timestamp")  # hack to get df in our "schema"
+    obj.mappings["tstep"] in names(df) && rename!(df, obj.mappings["tstep"] => "timestamp")  # hack to get df in our "schema"
     @info "get_dataset (id=$(repr(obj.id))) with names: $(names(df))"
     return df
 end


### PR DESCRIPTION
Ensures that when solving a calibrate, the solver will recognize which column has timestamp.

fixes https://github.com/DARPA-ASKEM/sciml-service/issues/143