### PR TITLE
Dataset timestamp col mapping

### DIFF
--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -424,7 +424,11 @@ function get_dataset(obj::JSON3.Object)
 
     for (k,v) in get(obj, :mappings, Dict())
         @info "`get_dataset` (dataset id=$(repr(obj.id))) rename! $k => $v"
-        rename!(df, k => v)
+        if k != "tstep"
+            rename!(df, k => v)
+        else
+            rename!(df, v => "timestamp") # hack to get df in our "schema"
+        end
     end
 
     @info "get_dataset (id=$(repr(obj.id))) with names: $(names(df))"

--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -412,14 +412,21 @@ end
 function get_dataset(obj::JSON3.Object)
     @assert ENABLE_TDS[]
     @info "get_dataset with obj = $(JSON3.write(obj))"
+
     tds_url = "$(TDS_URL[])/datasets/$(obj.id)/download-url?filename=$(obj.filename)"
     s3_url = get_json(tds_url).url
     df = CSV.read(download(s3_url), DataFrame)
+
+    # there should always be a mapping from the dataset timestamp column name to 'timestamp'
+    if !any(v -> v == "timestamp", values(obj.mappings))
+        @error "None of the values in obj.mappings are equal to 'timestamp'"
+    end
+
     for (k,v) in get(obj, :mappings, Dict())
         @info "`get_dataset` (dataset id=$(repr(obj.id))) rename! $k => $v"
         rename!(df, k => v)
     end
-    obj.mappings["tstep"] in names(df) && rename!(df, obj.mappings["tstep"] => "timestamp")  # hack to get df in our "schema"
+
     @info "get_dataset (id=$(repr(obj.id))) with names: $(names(df))"
     return df
 end

--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -419,7 +419,7 @@ function get_dataset(obj::JSON3.Object)
 
     # there should always be a mapping from the dataset timestamp column name to 'timestamp'
     if !any(v -> v == "timestamp", values(obj.mappings))
-        @error "None of the values in obj.mappings are equal to 'timestamp'"
+        @error "Expected mapping from <dataset timestamp column> to 'timestamp' not provided"
     end
 
     for (k,v) in get(obj, :mappings, Dict())


### PR DESCRIPTION
For calibrate, in order to know which dataset column has timestamp, we're going to require the request body to have a mapping from the dataset column name to the 'timestamp' string. So for example the request body may look like
```
{
...
  "mappings": {
    <dataset timestamp column name:: "timestamp",
    <dataset column name 1>: <model state var 1>,
    <dataset column name 2>: <model state var 2>,
    ...
  }
...
}
```