### PR TITLE
Update Julia version in docker file

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM julia:1.9
+FROM julia:1.10
 WORKDIR /sciml-service
 
 # Install SimulationService.jl

--- a/docker/docker_precompile.jl
+++ b/docker/docker_precompile.jl
@@ -1,5 +1,1 @@
 using SimulationService
-import ModelingToolkit: ODESystem
-import JSON3
-import HTTP
-SimulationService.amr_get(JSON3.read(HTTP.get("https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/sidarthe.json").body).configuration, ODESystem)


### PR DESCRIPTION
It looks like the docker image isn't being built in the CI. It has something to do with `Sundials.jl` not wanting to precompile I think. Maybe telling it that the Julia version is 1.10 will help?