### PR TITLE
Rudimentary progress tracking for simulate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -43,6 +43,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 julia = "1.10.1"
+ModelingToolkit = "8.75"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -43,7 +43,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 julia = "1.10.1"
-ModelingToolkit = "8.75"
+ModelingToolkit = "8.70"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -420,7 +420,7 @@ end
 function publish_to_rabbitmq(content)
     if !RABBITMQ_ENABLED[]
         # stop printing content for now, getting to be too much
-        @warn "RabbitMQ disabled - `publish_to_rabbitmq`" # with content $(JSON3.write(content))"
+        @warn "RabbitMQ disabled - `publish_to_rabbitmq` with content $(JSON3.write(content))"
         return content
     end
     json = Vector{UInt8}(codeunits(JSON3.write(content)))

--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -420,7 +420,7 @@ end
 function publish_to_rabbitmq(content)
     if !RABBITMQ_ENABLED[]
         # stop printing content for now, getting to be too much
-        @warn "RabbitMQ disabled - `publish_to_rabbitmq` with content $(JSON3.write(content))"
+        @warn "RabbitMQ disabled - `publish_to_rabbitmq`" #with content $(JSON3.write(content))"
         return content
     end
     json = Vector{UInt8}(codeunits(JSON3.write(content)))

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -222,22 +222,23 @@ function get_callback(o::OperationRequest, ::Type{Simulate})
     DiscreteCallback((args...) -> true, IntermediateResults(o.id,every = 10))
 end
 
+function (o::IntermediateResults)(integrator)
+    (; iter, f, t, u, p, sol) = integrator
+    t_end = sol.prob.tspan[2]
+    percent = round((t/t_end)*100.0, digits = 2)
+    if o.last_callback + o.every == iter
+        o.last_callback = iter
+        #state_dict = Dict(states(f.sys) .=> u)
+        #param_dict = Dict(parameters(f.sys) .=> p)
+        publish_to_rabbitmq(;id=o.id,
+            retcode=SciMLBase.check_error(integrator), percent = percent)
+    end
+    EasyModelAnalysis.DifferentialEquations.u_modified!(integrator, false)
+end
+
+
 # callback for Simulate requests
 function solve(op::Simulate; callback)
-
-    function (o::IntermediateResults)(integrator)
-        (; iter, f, t, u, p) = integrator
-        percent = round((t/op.timespan[2])*100.0, digits = 2)
-        if o.last_callback + o.every == iter
-            o.last_callback = iter
-            #state_dict = Dict(states(f.sys) .=> u)
-            #param_dict = Dict(parameters(f.sys) .=> p)
-            publish_to_rabbitmq(;id=o.id,
-                retcode=SciMLBase.check_error(integrator), percent = percent)
-        end
-        EasyModelAnalysis.DifferentialEquations.u_modified!(integrator, false)
-    end
-
     prob = ODEProblem(op.sys, [], op.timespan)
     sol = solve(prob; saveat=1, callback = nothing)
     @info "Timesteps returned are: $(sol.t)"

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -240,7 +240,7 @@ end
 # callback for Simulate requests
 function solve(op::Simulate; callback)
     prob = ODEProblem(op.sys, [], op.timespan)
-    sol = solve(prob; saveat=1, callback = nothing)
+    sol = solve(prob; saveat=1, callback = callback)
     @info "Timesteps returned are: $(sol.t)"
     dataframe_with_observables(sol)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,7 +206,9 @@ end
         obj = SimulationService.get_json(json_url).configuration
         sys = SimulationService.amr_get(obj, ODESystem)
         op = Simulate(sys, (0.0, 99.0))
-        df = solve(op; callback = nothing)
+        call_op = OperationRequest() # to test callback
+        call_op.id = "1"
+        df = solve(op; callback = SimulationService.get_callback(call_op,SimulationService.Simulate))
         @test df isa DataFrame
         @test extrema(df.timestamp) == (0.0, 99.0)
     end


### PR DESCRIPTION
Reports the time at certain iterations of the solver as a percentage of the full timespan. Gives a rudimentary estimate of the solvers progress. Also reports the job ID and the solver returncode. 