### PR TITLE
Pointing to legacy endpoint for model configs

### DIFF
--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -453,7 +453,7 @@ function get_model(id::String)
     @assert ENABLE_TDS[]
     @info "get_model($(repr(id)))"
 
-    tds_url = "$(TDS_URL[])/model-configurations/$id"
+    tds_url = "$(TDS_URL[])/model-configurations-legacy/$id"
 
     JSON3.read(HTTP.get(tds_url, [basic_auth_header[], json_content_header, snake_case_header]).body).configuration
 end


### PR DESCRIPTION
We are currently in the midst of a major refactor on model-configurations and are changing how the endpoints will work. As this system gets integrated we've kept the old model config objects and endpoints active until we're ready to flip the switch.

Note that this PR should not be merged until HMI-Server is updated to use these endpoints correctly.