### PR TITLE
 Update TA3 to use new configured model endpoints #3759

### DIFF
--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -453,7 +453,7 @@ function get_model(id::String)
     @assert ENABLE_TDS[]
     @info "get_model($(repr(id)))"
 
-    tds_url = "$(TDS_URL[])/model-configurations/$id"
+    tds_url = "$(TDS_URL[])/model-configurations/as-configured-model/$id"
 
     JSON3.read(HTTP.get(tds_url, [basic_auth_header[], json_content_header, snake_case_header]).body)
 end

--- a/src/SimulationService.jl
+++ b/src/SimulationService.jl
@@ -453,9 +453,9 @@ function get_model(id::String)
     @assert ENABLE_TDS[]
     @info "get_model($(repr(id)))"
 
-    tds_url = "$(TDS_URL[])/model-configurations-legacy/$id"
+    tds_url = "$(TDS_URL[])/model-configurations/$id"
 
-    JSON3.read(HTTP.get(tds_url, [basic_auth_header[], json_content_header, snake_case_header]).body).configuration
+    JSON3.read(HTTP.get(tds_url, [basic_auth_header[], json_content_header, snake_case_header]).body)
 end
 
 function get_dataset(obj::JSON3.Object)


### PR DESCRIPTION
# Description

* Pointing to the new HMI-server endpoints for the configured model

Resolves #3759
